### PR TITLE
Update for missing zero_one feature.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![feature(link_args)]
 #![feature(i128_type)]
 #![feature(i128)]
-#![feature(zero_one)]
 #![feature(libc)]
 #![feature(concat_idents)]
 #![feature(use_extern_macros)]


### PR DESCRIPTION
Nightly removed the `zero_one` feature, and it is currently deprecated and marked for [removal](https://github.com/rust-lang/rust/commit/c903ac64e58241a71ec42e791b0cc1451ffc3840). Since the f128 implementation doesn't rely on it, I've merely removed the line.