### PR TITLE
Added repository field to Cargo.toml for crates.io discoverability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Joshua Karns <jkarns275@gmail.com>"]
 build = "build.rs"
 license = "MIT"
 description = "Bindings to the gcc quadmath library"
+repository = "https://github.com/jkarns275/f128"
 
 [dependencies]
 num = "0.1"


### PR DESCRIPTION
I originally couldn't find the source for this crate. This should help others discover it as well