### PR TITLE
Added repr(C) to f128

### DIFF
--- a/src/f128_t.rs
+++ b/src/f128_t.rs
@@ -24,6 +24,7 @@ macro_rules! f128_from_x {
     })
 }
 
+#[repr(C)]
 #[derive(Clone, Copy)]
 pub struct f128(pub(crate) [u8; 16]);
 


### PR DESCRIPTION
Forgot this in my last PR, but `f128` should be repr C just in case due to use across ffi boundary.
It may be technically safe as is due to having only one field, but rust will also throw warnings about this, so repr(C) seems like a good idea anyway.