### PR TITLE
Fix failing test for subnormality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ mod tests {
         let pi = f128::PI;
         let one = f128::ONE;
         let half = f128!(0.5);
-        let min = f128::MIN_POSITIVE;
+        let min = f128::MIN_POSITIVE_SUBNORMAL;
 
         assert_eq!(half.classify(), FpCategory::Normal);
         assert_eq!(one.classify(), FpCategory::Normal);


### PR DESCRIPTION
`MIN_POSITIVE` is explicitly `MIN_POSITIVE_NORMAL`, and this PR fixes this failing test.
```
---- tests::test_classify stdout ----                                                                                                                                                          
thread 'tests::test_classify' panicked at 'assertion failed: `(left == right)`                 
  left: `Normal`,                                                                              
 right: `Subnormal`', src/lib.rs:144:9  
```