### PR TITLE
Add f128::{to_bits, from_bits}.

### DIFF
--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -275,13 +275,13 @@ impl Float for f128 {
     fn is_infinite(self) -> bool {
         // It's fine to compare the bits here since there is only 1 bit pattern that is inf, and one
         // that is -inf.
-        let res = self.inner_as_u128() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128;
-        res == f128::EXPONENT_BITS.inner_as_u128()
+        let res = self.to_bits() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128;
+        res == f128::EXPONENT_BITS.to_bits()
     }
 
     fn is_nan(self) -> bool {
-        (self.inner_as_u128() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128)
-            > f128::EXPONENT_BITS.inner_as_u128()
+        (self.to_bits() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128)
+            > f128::EXPONENT_BITS.to_bits()
     }
 
     #[inline]
@@ -292,7 +292,7 @@ impl Float for f128 {
     fn is_normal(self) -> bool {
         // Normal is defined as having an exponent not equal to 0
         let exp_bits = self.exp_bits();
-        self.inner_as_u128() == 0 || (exp_bits != 0 && exp_bits != 0x7FFF)
+        self.to_bits() == 0 || (exp_bits != 0 && exp_bits != 0x7FFF)
     }
 
     fn classify(self) -> FpCategory {
@@ -551,9 +551,9 @@ impl Neg for f128 {
     type Output = Self;
 
     fn neg(self) -> Self {
-        let mut bits = self.inner_as_u128();
-        bits ^= f128::SIGN_BIT.inner_as_u128();
-        f128::from_raw_u128(bits)
+        let mut bits = self.to_bits();
+        bits ^= f128::SIGN_BIT.to_bits();
+        f128::from_bits(bits)
     }
 }
 

--- a/f128_internal/src/f128_t.rs
+++ b/f128_internal/src/f128_t.rs
@@ -185,12 +185,12 @@ impl f128 {
     }
 
     #[inline(always)]
-    pub(crate) fn from_raw_u128(d: u128) -> Self {
+    pub fn from_bits(d: u128) -> Self {
         f128::from_arr(unsafe { mem::transmute::<u128, [u8; 16]>(d) })
     }
 
     #[inline(always)]
-    pub(crate) fn inner_as_u128(&self) -> u128 {
+    pub fn to_bits(self) -> u128 {
         unsafe { mem::transmute::<[u8; 16], u128>(self.0) }
     }
 
@@ -234,12 +234,12 @@ impl f128 {
     }
 
     pub fn exp_bits(&self) -> u32 {
-        let exp_bits = f128::EXPONENT_BITS.inner_as_u128();
-        ((self.inner_as_u128() & exp_bits) >> 112) as u32
+        let exp_bits = f128::EXPONENT_BITS.to_bits();
+        ((self.to_bits() & exp_bits) >> 112) as u32
     }
 
     pub fn fract_bits(&self) -> u128 {
-        self.inner_as_u128() & f128::FRACTION_BITS.inner_as_u128()
+        self.to_bits() & f128::FRACTION_BITS.to_bits()
     }
 
     pub fn bitwise_eq(self, other: Self) -> bool {


### PR DESCRIPTION
Rename `inner_as_u128` -> `to_bits`, `from_raw_u128` -> `from_bits`, and make them `pub`.

Matches {f32, f64}::{to_bits, from_bits} from stdlib.