### PR TITLE
Add f128::is_subnormal to match {f32, f64}::is_subnormal from stdlib.

### DIFF
--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -338,8 +338,8 @@ impl Float for f128 {
     }
 
     fn signum(self) -> Self {
-        if self == Self::NAN {
-            return self;
+        if self.is_nan() {
+            Self::NAN
         } else {
             if self.is_sign_positive() {
                 Self::ONE

--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -296,12 +296,18 @@ impl Float for f128 {
     }
 
     fn classify(self) -> FpCategory {
-        let x = (self.is_normal(), self.is_finite(), self.is_nan());
-        match x {
-            (true, true, false) => FpCategory::Normal,
-            (false, true, false) => FpCategory::Subnormal,
-            (_, _, true) => FpCategory::Nan,
-            (_, false, _) => FpCategory::Infinite,
+        if self.is_infinite() {
+            FpCategory::Infinite
+        } else if self.is_nan() {
+            FpCategory::Nan
+        } else {
+            let exp_bits = self.exp_bits();
+            let mant_bits = self.fract_bits();
+            match (exp_bits, mant_bits) {
+                (0, 0) => FpCategory::Zero,
+                (0, _) => FpCategory::Subnormal,
+                (_, _) => FpCategory::Normal,
+            }
         }
     }
 

--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -553,6 +553,12 @@ impl Float for f128 {
     }
 }
 
+impl f128 {
+    pub fn is_subnormal(&self) -> bool {
+        self.classify() == FpCategory::Subnormal
+    }
+}
+
 impl Neg for f128 {
     type Output = Self;
 

--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -275,13 +275,13 @@ impl Float for f128 {
     fn is_infinite(self) -> bool {
         // It's fine to compare the bits here since there is only 1 bit pattern that is inf, and one
         // that is -inf.
-        let res = self.inner_as_u128() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128;
-        res == f128::EXPONENT_BITS.inner_as_u128()
+        let res = self.to_bits() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128;
+        res == f128::EXPONENT_BITS.to_bits()
     }
 
     fn is_nan(self) -> bool {
-        (self.inner_as_u128() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128)
-            > f128::EXPONENT_BITS.inner_as_u128()
+        (self.to_bits() & 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFu128)
+            > f128::EXPONENT_BITS.to_bits()
     }
 
     #[inline]
@@ -292,7 +292,7 @@ impl Float for f128 {
     fn is_normal(self) -> bool {
         // Normal is defined as having an exponent not equal to 0
         let exp_bits = self.exp_bits();
-        self.inner_as_u128() == 0 || (exp_bits != 0 && exp_bits != 0x7FFF)
+        self.to_bits() == 0 || (exp_bits != 0 && exp_bits != 0x7FFF)
     }
 
     fn classify(self) -> FpCategory {
@@ -551,9 +551,9 @@ impl Neg for f128 {
     type Output = Self;
 
     fn neg(self) -> Self {
-        let mut bits = self.inner_as_u128();
-        bits ^= f128::SIGN_BIT.inner_as_u128();
-        f128::from_raw_u128(bits)
+        let mut bits = self.to_bits();
+        bits ^= f128::SIGN_BIT.to_bits();
+        f128::from_bits(bits)
     }
 }
 

--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -290,9 +290,9 @@ impl Float for f128 {
     }
 
     fn is_normal(self) -> bool {
-        // Normal is defined as having an exponent not equal to 0
+        // Normal is defined as having an exponent not equal to 0 and being finite
         let exp_bits = self.exp_bits();
-        self.to_bits() == 0 || (exp_bits != 0 && exp_bits != 0x7FFF)
+        exp_bits != 0 && exp_bits != 0x7FFF
     }
 
     fn classify(self) -> FpCategory {

--- a/f128_internal/src/f128_t.rs
+++ b/f128_internal/src/f128_t.rs
@@ -185,12 +185,12 @@ impl f128 {
     }
 
     #[inline(always)]
-    pub(crate) fn from_raw_u128(d: u128) -> Self {
+    pub fn from_bits(d: u128) -> Self {
         f128::from_arr(unsafe { mem::transmute::<u128, [u8; 16]>(d) })
     }
 
     #[inline(always)]
-    pub(crate) fn inner_as_u128(&self) -> u128 {
+    pub fn to_bits(self) -> u128 {
         unsafe { mem::transmute::<[u8; 16], u128>(self.0) }
     }
 
@@ -234,12 +234,12 @@ impl f128 {
     }
 
     pub fn exp_bits(&self) -> u32 {
-        let exp_bits = f128::EXPONENT_BITS.inner_as_u128();
-        ((self.inner_as_u128() & exp_bits) >> 112) as u32
+        let exp_bits = f128::EXPONENT_BITS.to_bits();
+        ((self.to_bits() & exp_bits) >> 112) as u32
     }
 
     pub fn fract_bits(&self) -> u128 {
-        self.inner_as_u128() & f128::FRACTION_BITS.inner_as_u128()
+        self.to_bits() & f128::FRACTION_BITS.to_bits()
     }
 
     pub fn bitwise_eq(self, other: Self) -> bool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,11 +149,15 @@ mod tests {
         let one = f128::ONE;
         let half = f128!(0.5);
         let min = f128::MIN_POSITIVE_SUBNORMAL;
+        let zero = f128::ZERO;
+        let minzero = f128::NEG_ZERO;
 
         assert_eq!(half.classify(), FpCategory::Normal);
         assert_eq!(one.classify(), FpCategory::Normal);
         assert_eq!(pi.classify(), FpCategory::Normal);
         assert_eq!(min.classify(), FpCategory::Subnormal);
+        assert_eq!(zero.classify(), FpCategory::Zero);
+        assert_eq!(minzero.classify(), FpCategory::Zero);
         assert_eq!(f128::INFINITY.classify(), FpCategory::Infinite);
         assert_eq!(f128::NEG_INFINITY.classify(), FpCategory::Infinite);
         assert_eq!(f128::NAN.classify(), FpCategory::Nan);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,11 +129,18 @@ mod tests {
         assert!(f128::MIN.is_finite());
 
         assert!(f128::MIN_POSITIVE.is_finite());
+        assert!(f128::MIN_POSITIVE.is_normal());
         assert!(!f128::MIN_POSITIVE.is_nan());
 
-        assert!(f128::MIN_POSITIVE.is_finite());
-        assert!(!f128::MIN_POSITIVE.is_nan());
+        assert!(f128::MIN_POSITIVE_SUBNORMAL.is_finite());
+        assert!(!f128::MIN_POSITIVE_SUBNORMAL.is_normal());
+        assert!(!f128::MIN_POSITIVE_SUBNORMAL.is_nan());
 
+        assert!(!f128::ZERO.is_normal());
+        assert!(!f128::ZERO.is_infinite());
+        assert!(!f128::ZERO.is_nan());
+        assert!(f128::ZERO.is_finite());
+        assert!(f128::ZERO.is_zero());
     }
 
     #[test]
@@ -177,16 +184,18 @@ mod tests {
     fn test_is_normal() {
         let min = f128::MIN_POSITIVE;
         let max = f128::MAX;
-        let zero = 0.0f32;
+        let zero = f128::ZERO;
+        let minzero = f128::NEG_ZERO;
         let one = f128::ONE;
         let minone = -f128::ONE;
 
         assert!(one.is_normal());
         assert!(minone.is_normal());
-        assert!(min.is_normal()); // fails
-        assert!(max.is_normal()); //fails
+        assert!(min.is_normal());
+        assert!(max.is_normal());
 
         assert!(!zero.is_normal());
+        assert!(!minzero.is_normal());
         assert!(!f128::NAN.is_normal());
         assert!(!f128::INFINITY.is_normal());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,27 @@ mod tests {
     }
 
     #[test]
+    fn test_signum() {
+        let inf = f128::INFINITY;
+        let mininf = f128::NEG_INFINITY;
+        let nan = f128::NAN;
+        let minnan = -f128::NAN;
+        let zero = f128::ZERO;
+        let minzero = f128::NEG_ZERO;
+        let one = f128::ONE;
+        let minone = -f128::ONE;
+
+        assert_eq!(inf.signum(), one);
+        assert_eq!(mininf.signum(), minone);
+        assert!(nan.signum().is_nan());
+        assert!(minnan.signum().is_nan());
+        assert_eq!(zero.signum(), one);
+        assert_eq!(minzero.signum(), minone);
+        assert_eq!(one.signum(), one);
+        assert_eq!(minone.signum(), minone);
+    }
+
+    #[test]
     fn test_is_normal() {
         let min = f128::MIN_POSITIVE;
         let max = f128::MAX;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,13 +130,16 @@ mod tests {
 
         assert!(f128::MIN_POSITIVE.is_finite());
         assert!(f128::MIN_POSITIVE.is_normal());
+        assert!(!f128::MIN_POSITIVE.is_subnormal());
         assert!(!f128::MIN_POSITIVE.is_nan());
 
         assert!(f128::MIN_POSITIVE_SUBNORMAL.is_finite());
         assert!(!f128::MIN_POSITIVE_SUBNORMAL.is_normal());
+        assert!(f128::MIN_POSITIVE_SUBNORMAL.is_subnormal());
         assert!(!f128::MIN_POSITIVE_SUBNORMAL.is_nan());
 
         assert!(!f128::ZERO.is_normal());
+        assert!(!f128::ZERO.is_subnormal());
         assert!(!f128::ZERO.is_infinite());
         assert!(!f128::ZERO.is_nan());
         assert!(f128::ZERO.is_finite());


### PR DESCRIPTION
Rust 1.53.0 introduced `{f32, f64}::is_subnormal`. This PR adds this function to f128.

This PR is based on #34 and #35, but can be cherry-picked alone if those are not accepted (though one of the tests will fail without #35).