### PR TITLE
Align ffi::Wrapper on Rust side to match C side.

### DIFF
--- a/f128_internal/src/ffi.rs
+++ b/f128_internal/src/ffi.rs
@@ -2,7 +2,7 @@ use f128_t::f128;
 use libc::c_int;
 use libc::c_longlong;
 
-#[repr(C)]
+#[repr(C, align(16))]
 pub(crate) struct Wrapper([u8; 16]);
 
 #[link(name = "f128", kind = "static")]


### PR DESCRIPTION
f128.c has `__attribute__((aligned(16))` on Wrapper.
This commit adds the analogous `repr(align(16))` to struct Wrapper in ffi.rs.