### PR TITLE
Add f128::total_cmp to match stdlib.

### DIFF
--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -553,6 +553,12 @@ impl Float for f128 {
     }
 }
 
+impl f128 {
+    pub fn is_subnormal(&self) -> bool {
+        self.classify() == FpCategory::Subnormal
+    }
+}
+
 impl Neg for f128 {
     type Output = Self;
 

--- a/f128_internal/src/f128_impl.rs
+++ b/f128_internal/src/f128_impl.rs
@@ -557,6 +557,20 @@ impl f128 {
     pub fn is_subnormal(&self) -> bool {
         self.classify() == FpCategory::Subnormal
     }
+
+    /// Return the ordering between `self` and `other` in accordance to
+    /// the `totalOrder` predicate as defined in the IEEE 754 (2008 revision),
+    /// as implemented in `core` for `f32` and `f64`.
+    pub fn total_cmp(&self, rhs: &Self) -> Ordering {
+        // See f32::total_cmp or f64::total_cmp in `core` for explanation.
+        let mut left = self.to_bits() as i128;
+        let mut right = rhs.to_bits() as i128;
+
+        left ^= (((left >> 127) as u128) >> 1) as i128;
+        right ^= (((right >> 127) as u128) >> 1) as i128;
+
+        left.cmp(&right)
+    }
 }
 
 impl Neg for f128 {

--- a/f128_internal/src/lib.rs
+++ b/f128_internal/src/lib.rs
@@ -13,7 +13,7 @@ mod tests {
 
     use super::*;
     use num_traits::*;
-    use std::num::FpCategory;
+    use std::{num::FpCategory, cmp::Ordering};
 
     #[test]
     fn test_minus() {
@@ -178,5 +178,40 @@ mod tests {
         assert!(b > a);
         assert!(b >= a);
         assert!(a != b);
+    }
+
+    #[test]
+    fn test_total_cmp() {
+        let a = f128::parse("-1.5").unwrap();
+        let b = f128::parse("1.5").unwrap();
+        let c = f128::parse("3.0").unwrap();
+
+        assert_eq!(a.total_cmp(&a), Ordering::Equal);
+        assert_eq!(a.total_cmp(&b), Ordering::Less);
+        assert_eq!(a.total_cmp(&c), Ordering::Less);
+        assert_eq!(b.total_cmp(&a), Ordering::Greater);
+        assert_eq!(b.total_cmp(&b), Ordering::Equal);
+        assert_eq!(b.total_cmp(&c), Ordering::Less);
+        assert_eq!(c.total_cmp(&a), Ordering::Greater);
+        assert_eq!(c.total_cmp(&b), Ordering::Greater);
+        assert_eq!(c.total_cmp(&c), Ordering::Equal);
+
+        let nan = f128::NAN;
+        let minnan = -f128::NAN;
+        let inf = f128::INFINITY;
+        let mininf = f128::NEG_INFINITY;
+
+        assert_eq!(nan.total_cmp(&nan), Ordering::Equal);
+        assert_eq!(nan.total_cmp(&minnan), Ordering::Greater);
+        assert_eq!(minnan.total_cmp(&nan), Ordering::Less);
+        assert_eq!(minnan.total_cmp(&minnan), Ordering::Equal);
+        assert_eq!(nan.total_cmp(&inf), Ordering::Greater);
+        assert_eq!(nan.total_cmp(&mininf), Ordering::Greater);
+        assert_eq!(minnan.total_cmp(&inf), Ordering::Less);
+
+        assert_eq!(nan.total_cmp(&a), Ordering::Greater);
+        assert_eq!(minnan.total_cmp(&a), Ordering::Less);
+        assert_eq!(inf.total_cmp(&a), Ordering::Greater);
+        assert_eq!(mininf.total_cmp(&a), Ordering::Less);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,13 +130,16 @@ mod tests {
 
         assert!(f128::MIN_POSITIVE.is_finite());
         assert!(f128::MIN_POSITIVE.is_normal());
+        assert!(!f128::MIN_POSITIVE.is_subnormal());
         assert!(!f128::MIN_POSITIVE.is_nan());
 
         assert!(f128::MIN_POSITIVE_SUBNORMAL.is_finite());
         assert!(!f128::MIN_POSITIVE_SUBNORMAL.is_normal());
+        assert!(f128::MIN_POSITIVE_SUBNORMAL.is_subnormal());
         assert!(!f128::MIN_POSITIVE_SUBNORMAL.is_nan());
 
         assert!(!f128::ZERO.is_normal());
+        assert!(!f128::ZERO.is_subnormal());
         assert!(!f128::ZERO.is_infinite());
         assert!(!f128::ZERO.is_nan());
         assert!(f128::ZERO.is_finite());


### PR DESCRIPTION
Rust 1.62.0 introduced {f32, f64}::total_cmp. This PR adds this function to f128 (Note: this PR does **not** require compiling this crate with Rust 1.62.0).

`total_cmp` returns the ordering between self and other in accordance to the totalOrder predicate as defined in the IEEE 754 (2008 revision) floating point standard, which defines a precise ordering for all values, inclusing `NaN`s, which are incomparable under normal comparison.

This PR is based on #36, but can be separated.