### PR TITLE
Propagate parse errors from strtoflt128; implement FromStr for f128

### DIFF
--- a/f128_input/src/lib.rs
+++ b/f128_input/src/lib.rs
@@ -14,7 +14,7 @@ fn parse(s: &str) -> String {
                 "unsafe {{ ::std::mem::transmute::<[u8; 16], f128>({:?}) }}",
                 it.into_inner()
             ),
-        Err(_) => panic!(format!("'{:?}' is not a valid f128", s)),
+        Err(_) => panic!("'{:?}' is not a valid f128", s),
     }
 }
 

--- a/f128_internal/src/f128.c
+++ b/f128_internal/src/f128.c
@@ -12,8 +12,8 @@ typedef union _Wrapper {
   char dat_alt[16];
 } __attribute__ ((aligned (16))) Wrapper;
 
-Wrapper strtoflt128_f(const char *s) {
-  return (Wrapper) { strtoflt128(s, NULL) };
+Wrapper strtoflt128_f(const char *s, char **end) {
+  return (Wrapper) { strtoflt128(s, end) };
 }
 
 #define x_to_f128(x, n) Wrapper n##_to_f128(x a) {    \

--- a/f128_internal/src/ffi.rs
+++ b/f128_internal/src/ffi.rs
@@ -15,7 +15,7 @@ extern "C" {
 
     pub fn qtostr(s: *mut u8, size: usize, fmt: *const i8, arg: f128) -> c_int;
 
-    pub fn strtoflt128_f(c: *const i8) -> f128;
+    pub fn strtoflt128_f(c: *const i8, end: *mut *const i8) -> f128;
 
     pub(crate) fn usize_to_f128(x: usize) -> f128;
     pub(crate) fn f128_to_usize(x: f128) -> usize;


### PR DESCRIPTION
`strtoflt128` signals errors through an `char** end` pointer which is used as an iterator through the string. If the input string is parsed correctly, this pointer will be advanced to the trailing null byte at the end of the string, and if it failed to parse, it will be at the location in the string where it encountered an error. By failing to check this pointer, the previous parse implementation. This is especially bad since the parse implementation is used in the `f128_inner!` macro to parse f128 literals -- in the event of a syntax error that isn't the inclusion of a non-trailing null byte, the output would silently truncate the result to the last digit it could parse or fall back to 0.0 if the first character was non-numeric, without any indication that a syntax error was present.

Examples of input which was parsed incorrectly (all now correctly report as errors with this PR):

```rust
let x = f128!(0.3O9); // number 3 letter O number 9
assert_eq!(x, f128!(0.3));

let y = f128!({});
assert_eq!(y, f128!(0.0));

let z = f128!(10 + 10);
assert_eq!(z, f128!(10));
```

This PR fixes the `f128::parse()` function to verify the `end` pointer before returning, using an error type adapted from [`std::num::ParseFloatError`](https://doc.rust-lang.org/std/num/struct.ParseFloatError.html), and adds an implementation of [`std::str::FromStr`](https://doc.rust-lang.org/std/str/trait.FromStr.html) for compatibility with [`str::parse()`](https://doc.rust-lang.org/std/primitive.str.html#method.parse).

This is a breaking change in both API (changing the error type of `f128::parse()` to a new `ParseF128Error` type instead of `std::ffi::NulError`) and behavior (values which were previously truncated now fail to parse), and would require a major version update to `f128` and `f128_internal`. Also includes a commit which updates a panic macro to more modern syntax to squelch a compilation warning, which would require a minor version update to `f128_input`.